### PR TITLE
Use safe load instead of load file.

### DIFF
--- a/lib/russian_workdays/day.rb
+++ b/lib/russian_workdays/day.rb
@@ -3,9 +3,9 @@
 require "yaml"
 
 module RussianWorkdays
-  DATES = YAML.safe_load(
+  DATES = YAML.load_file(
     File.join(__dir__, 'dates.yml'),
-    permitted_classes: [Date]
+    permitted_classes: [Date, Symbol]
   ).freeze
 
   class Day

--- a/lib/russian_workdays/day.rb
+++ b/lib/russian_workdays/day.rb
@@ -3,7 +3,10 @@
 require "yaml"
 
 module RussianWorkdays
-  DATES = YAML.load_file(File.join(__dir__, "dates.yml")).freeze
+  DATES = YAML.safe_load(
+    File.join(__dir__, 'dates.yml'),
+    permitted_classes: [Date]
+  ).freeze
 
   class Day
     def initialize(date)

--- a/russian_workdays.gemspec
+++ b/russian_workdays.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.6.3'
+
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Чинит:
```
`rescue in block (2 levels) in require': There was an error while trying to load the gem 'russian_workdays'. (Bundler::GemRequireError)
Gem Load Error is: Tried to load unspecified class: Date
```
из-за способа загрузки `config.active_record.yaml_column_permitted_classes` игнорится, а манки-патчить это такое себе
